### PR TITLE
Fix "An Error Occurred While Accessing The File"

### DIFF
--- a/usr/lib/linuxmint/mintBackup/mintBackup.py
+++ b/usr/lib/linuxmint/mintBackup/mintBackup.py
@@ -1588,12 +1588,10 @@ class MintBackup:
 					if(not pkg.isInstalled):
 						desc = pkg.candidate.summary.replace("&", "&amp;")
 						line = "<big>" + line + "</big>\n<small>" + desc + "</small>"
-						gtk.gdk.threads_enter()
-						model.append([inst, line, inst, pkg.name])
-						gtk.gdk.threads_leave()
-				else:
-					inst = False
-					line = "<big>" + line + "</big>\n<small>" + _("Could not locate the package") + "</small>"
+					else:
+						inst = False
+						line = "<big>" + line + "</big>\n<small>" + _("Could not locate the package") + "</small>"
+
 					gtk.gdk.threads_enter()
 					model.append([inst, line, inst, pkg.name])
 					gtk.gdk.threads_leave()


### PR DESCRIPTION
https://bugs.launchpad.net/linuxmint/+bug/722522

Running mintBackup.py from console it shown 'variable pkg is used before
initializing' python error. It looks like it happens because of incorrect 'else'
block indentation.
