### PR TITLE
Pass on $HOME and $PATH to mintbackup

### DIFF
--- a/usr/bin/mintbackup
+++ b/usr/bin/mintbackup
@@ -4,5 +4,5 @@ import os
 import subprocess
 
 launcher = subprocess.getoutput("/usr/lib/linuxmint/common/mint-which-launcher.py")
-command = "%s /usr/lib/linuxmint/mintbackup/mintbackup.py" % (launcher)
+command = '%s env PATH="$PATH" HOME="$HOME"  /usr/lib/linuxmint/mintbackup/mintbackup.py' % (launcher)
 os.system(command)


### PR DESCRIPTION
Close #37 

Wasn't tested on KDE. As mint-which-launcher.py may use kdesudo for password prompting, I'd be interested in knowing rather this will not break the software for KDE users. Seemingly fixed the issue on 18.1