### PR TITLE
Fix high memory usage and eventual crash when restoring a .list

### DIFF
--- a/usr/share/linuxmint/mintbackup/mintbackup.ui
+++ b/usr/share/linuxmint/mintbackup/mintbackup.ui
@@ -1278,19 +1278,13 @@
                         <property name="can_focus">True</property>
                         <property name="shadow_type">out</property>
                         <child>
-                          <object class="GtkViewport" id="viewport4">
+                          <object class="GtkTreeView" id="treeview_package_list">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="resize_mode">queue</property>
-                            <child>
-                              <object class="GtkTreeView" id="treeview_package_list">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="headers_visible">False</property>
-                                <child internal-child="selection">
-                                  <object class="GtkTreeSelection"/>
-                                </child>
-                              </object>
+                            <property name="can_focus">True</property>
+                            <property name="headers_visible">False</property>
+                            <property name="enable_search">False</property>
+                            <child internal-child="selection">
+                              <object class="GtkTreeSelection"/>
                             </child>
                           </object>
                         </child>


### PR DESCRIPTION
containing a large number of packages.
    
This is a bug with GtkViewport/the combination of a GtkScrolledWindow and a GtkViewport and in mintbackup actually a regression. It had previously been fixed in mintbackup in e7671a45df7a93d64b9090d4786f7745cd991b9f for Gtk2, apparently the issue remains with Gtk3 and was reintroduced later back into mintbackup with 062b95a966a85389e753d9948c136458bffa5945. 

Fixes #59 and https://github.com/linuxmint/linuxmint/issues/91