### PR TITLE
Use mintbackup.py relative to where mintbackup is located

### DIFF
--- a/usr/bin/mintbackup
+++ b/usr/bin/mintbackup
@@ -1,5 +1,10 @@
 #!/usr/bin/python3
 
 import os
+import sys
+from pathlib import Path
 
-os.system("/usr/lib/linuxmint/mintbackup/mintbackup.py")
+bin_path = Path(sys.argv[0]).absolute()
+lib_path = bin_path.joinpath(bin_path.parents[1], "lib/linuxmint/mintbackup/mintbackup.py")
+
+os.system(lib_path)


### PR DESCRIPTION
Hi

I've just cloned the repo, made a change and then realised that ./usr/bin/mintbackup was still running the system one. This change runs the version alongside the ./usr/bin/mintbackup, so you can run the version you're developing without having to install the package. :)

(Now I think of it I could have just run ./usr/lib/mintbackup.py directly ... but this still seems worth doing.)

Thanks
Paul