### PR TITLE
Add support for wildcards

### DIFF
--- a/usr/lib/linuxmint/mintbackup/mintbackup.py
+++ b/usr/lib/linuxmint/mintbackup/mintbackup.py
@@ -117,8 +117,7 @@ class MintBackup:
         self.builder.get_object("button_remove_exclude").connect("clicked", self.remove_item_from_treeview, treeview)
         self.builder.get_object("treeview_excludes_selection").connect("changed", self.on_treeview_excludes_selection_changed)
 
-        # set up exclude wildcards window
-        exclude_treeview = treeview
+        # set up wildcards window
         treeview = self.builder.get_object("treeview_wildcard")
         renderer = Gtk.CellRendererPixbuf()
         column = Gtk.TreeViewColumn("", renderer)
@@ -128,16 +127,16 @@ class MintBackup:
         column = Gtk.TreeViewColumn("", renderer)
         column.add_attribute(renderer, "text", 0)
         treeview.append_column(column)
-        self.excludes_model = Gtk.ListStore(str, GdkPixbuf.Pixbuf, str)
-        self.excludes_model.set_sort_column_id(0, Gtk.SortType.ASCENDING)
-        treeview.set_model(self.excludes_model)
+        excludes_model = Gtk.ListStore(str, GdkPixbuf.Pixbuf, str)
+        excludes_model.set_sort_column_id(0, Gtk.SortType.ASCENDING)
+        treeview.set_model(excludes_model)
 
         wildcard_submit_button = self.builder.get_object("button_wildcard_submit")
         wildcard_entry = self.builder.get_object("wildcard_entry")
         wildcard_help_icon = self.iconTheme.load_icon("xsi-dialog-question-symbolic", 16, 0)
         wildcard_entry.set_icon_from_gicon(Gtk.EntryIconPosition.SECONDARY, wildcard_help_icon)
         wildcard_entry.connect("changed", self.try_add_wildcard_to_treeview, treeview, None, wildcard_submit_button, True)
-        self.builder.get_object("button_wildcard_submit").connect("clicked", self.try_add_wildcard_to_treeview, exclude_treeview, wildcard_entry, None, False)
+        self.builder.get_object("button_wildcard_submit").connect("clicked", self.try_add_wildcard_to_treeview, None, wildcard_entry, None, False)
         self.builder.get_object("button_wildcard_cancel").connect("clicked", lambda _: self.wildcard_window_hide(wildcard_window, wildcard_entry, treeview, wildcard_submit_button))
 
         # set up inclusions page

--- a/usr/lib/linuxmint/mintbackup/mintbackup.py
+++ b/usr/lib/linuxmint/mintbackup/mintbackup.py
@@ -478,7 +478,7 @@ class MintBackup:
         # validate user input
         if not self.wildcard_is_valid(entry_path):
             # warn the user
-            return
+            return [], []
 
         # match wildcards
         structure = entry_path.split("/")
@@ -503,7 +503,7 @@ class MintBackup:
 
                 # insert file/pattern prefixes
                 # completions = [parent_pattern + entry.name for entry in entries if entry.is_dir() and entry.name in filtered_completions]
-                stored_directories.extend([path + "/" + entry.name for entry in entries if entry.is_dir() and entry.name in filtered])
+                stored_directories.extend([entry.path for entry in entries if entry.is_dir() and entry.name in filtered])
                 stored_files.extend([path + "/" + name for name in filtered if name not in stored_directories])
             scan_directories.clear()
             scan_directories.extend(stored_directories)
@@ -512,7 +512,7 @@ class MintBackup:
 
         # i tried i cant add autocompletion
         # if anyone wants to attempt this, code to generate completions is commented out above
-        return stored_directories, stored_files
+        return scan_directories, stored_files
 
     def wildcard_is_valid(self, path):
         home_dir = self.home_directory
@@ -557,7 +557,7 @@ class MintBackup:
                     if full_path not in existing_paths:
                         if os.path.isfile(full_path):
                             new_items.append([item, self.file_icon, full_path])
-
+            print(new_items)
             for item in new_items:
                 model.append(item)
         else:

--- a/usr/lib/linuxmint/mintbackup/mintbackup.py
+++ b/usr/lib/linuxmint/mintbackup/mintbackup.py
@@ -533,7 +533,6 @@ class MintBackup:
         return is_valid
 
     def try_add_wildcard_to_treeview(self, widget, treeview, entry, expanded):
-        home_dir = self.home_directory
         if expanded:
             entry = widget.get_text()
             directories, files = self.get_expanded_paths(entry)
@@ -542,8 +541,6 @@ class MintBackup:
 
             # add paths to treeview
             model = treeview.get_model()
-
-            existing_paths = {row[2] for row in model}
 
             new_items = []
             for full_path in directories:

--- a/usr/lib/linuxmint/mintbackup/mintbackup.py
+++ b/usr/lib/linuxmint/mintbackup/mintbackup.py
@@ -4,6 +4,7 @@ import gettext
 import hashlib
 import locale
 import os
+import pprint
 import stat
 import sys
 import tarfile
@@ -597,7 +598,7 @@ class MintBackup:
         else:
             entry_path = entry.get_text()
             paths = self.get_expanded_paths(entry_path)
-            if paths is None:
+            if paths is None or entry_path == "":
                 widget.get_style_context().add_class("error")
                 return
             widget.get_style_context().remove_class("error")

--- a/usr/lib/linuxmint/mintbackup/mintbackup.py
+++ b/usr/lib/linuxmint/mintbackup/mintbackup.py
@@ -4,7 +4,6 @@ import gettext
 import hashlib
 import locale
 import os
-import pprint
 import stat
 import sys
 import tarfile

--- a/usr/lib/linuxmint/mintbackup/mintbackup.py
+++ b/usr/lib/linuxmint/mintbackup/mintbackup.py
@@ -119,7 +119,7 @@ class MintBackup:
 
         # set up exclusion wildcards window
         exclude_treeview = treeview
-        treeview = self.builder.get_object("treeview_excludes")
+        treeview = self.builder.get_object("treeview_wildcard_exclude")
         renderer = Gtk.CellRendererPixbuf()
         column = Gtk.TreeViewColumn("", renderer)
         column.add_attribute(renderer, "pixbuf", 1)
@@ -544,20 +544,16 @@ class MintBackup:
             existing_paths = {row[2] for row in model}
 
             new_items = []
-            for item in directories:
-                if item.startswith('.'):
-                    full_path = os.path.join(home_dir, item)
-                    if full_path not in existing_paths:
-                        if os.path.isdir(full_path):
-                            new_items.append([item, self.dir_icon, full_path])
+            for full_path in directories:
+                if full_path not in existing_paths:
+                    _, item = os.path.split(full_path)
+                    new_items.append([item, self.dir_icon, full_path])
 
-            for item in files:
-                if item.startswith('.'):
-                    full_path = os.path.join(home_dir, item)
-                    if full_path not in existing_paths:
-                        if os.path.isfile(full_path):
-                            new_items.append([item, self.file_icon, full_path])
-            print(new_items)
+            for full_path in files:
+                if full_path not in existing_paths:
+                    _, item = os.path.split(full_path)
+                    new_items.append([item, self.file_icon, full_path])
+
             for item in new_items:
                 model.append(item)
         else:

--- a/usr/lib/linuxmint/mintbackup/mintbackup.py
+++ b/usr/lib/linuxmint/mintbackup/mintbackup.py
@@ -102,9 +102,14 @@ class MintBackup:
         self.excludes_model.append([BACKUP_DIR[len(self.home_directory) + 1:], self.dir_icon, BACKUP_DIR])
         excluded_paths.append(BACKUP_DIR)
         for item in self.settings.get_strv("excluded-paths"):
-            # BUG: gsettings init bug here
+            is_wildcard = item.startswith("wc:")
+            if is_wildcard:
+                item = item[3:]
+                item = os.path.expanduser(item)
+                self.excludes_model.append([f"{_("Wildcard")}: {item[len(self.home_directory) + 1:]}", self.dir_icon, item])
+                continue
             item = os.path.expanduser(item)
-            if os.path.exists(item) and item not in excluded_paths:
+            if os.path.exists(item) and item not in excluded_paths and not is_wildcard:
                 excluded_paths.append(item)
                 if os.path.isdir(item):
                     self.excludes_model.append([item[len(self.home_directory) + 1:], self.dir_icon, item])
@@ -154,9 +159,15 @@ class MintBackup:
         self.includes_model.set_sort_column_id(0, Gtk.SortType.ASCENDING)
         treeview.set_model(self.includes_model)
         for item in self.settings.get_strv("included-hidden-paths"):
-            item = os.path.expanduser(item)
-            if os.path.exists(item):
-                if os.path.isdir(item):
+            is_wildcard = item.startswith("wc:")
+            if is_wildcard:
+                item = item[3:]
+                item = os.path.expanduser(item)
+                self.includes_model.append([f"{_("Wildcard")}: {item[len(self.home_directory) + 1:]}", self.dir_icon, item])
+                continue
+            os.path.expanduser(item)
+            if os.path.exists(item) or is_wildcard:
+                if os.path.isdir(item) or is_wildcard:
                     self.includes_model.append([item[len(self.home_directory) + 1:], self.dir_icon, item])
                 else:
                     self.includes_model.append([item[len(self.home_directory) + 1:], self.file_icon, item])
@@ -380,7 +391,11 @@ class MintBackup:
             for row in self.excludes_model:
                 path = row[2]
                 path = path.replace(self.home_directory, "~")
-                excludes.append(path)
+                if row[0].startswith(_("Wildcard")):
+                    # insert prefix to separate from normal paths during gsettings load
+                    excludes.append("wc:" + path)
+                else:
+                    excludes.append(path)
             self.settings.set_strv("excluded-paths", excludes)
             # Calculate includes
             self.included_dirs = []
@@ -401,7 +416,11 @@ class MintBackup:
             for row in self.includes_model:
                 path = row[2]
                 path = path.replace(self.home_directory, "~")
-                includes.append(path)
+                if row[0].startswith(_("Wildcard")):
+                    # insert prefix to separate from normal paths during gsettings load
+                    includes.append("wc:" + path)
+                else:
+                    includes.append(path)
             self.settings.set_strv("included-hidden-paths", includes)
             thread = threading.Thread(target=self.backup)
             thread.daemon = True

--- a/usr/lib/linuxmint/mintbackup/mintbackup.py
+++ b/usr/lib/linuxmint/mintbackup/mintbackup.py
@@ -132,12 +132,13 @@ class MintBackup:
         self.excludes_model.set_sort_column_id(0, Gtk.SortType.ASCENDING)
         treeview.set_model(self.excludes_model)
 
+        wildcard_submit_button = self.builder.get_object("button_wildcard_submit")
         wildcard_entry = self.builder.get_object("exclude_wildcard_entry")
         wildcard_help_icon = self.iconTheme.load_icon("xsi-dialog-question-symbolic", 16, 0)
         wildcard_entry.set_icon_from_gicon(Gtk.EntryIconPosition.SECONDARY, wildcard_help_icon)
-        wildcard_entry.connect("changed", self.try_add_wildcard_to_treeview, treeview, None, True)
-        self.builder.get_object("button_wildcard_submit").connect("clicked", self.try_add_wildcard_to_treeview, exclude_treeview, wildcard_entry, False)
-        self.builder.get_object("button_wildcard_cancel").connect("clicked", lambda _: self.wildcard_window_hide(wildcard_exclude_window, wildcard_entry, treeview))
+        wildcard_entry.connect("changed", self.try_add_wildcard_to_treeview, treeview, None, wildcard_submit_button, True)
+        self.builder.get_object("button_wildcard_submit").connect("clicked", self.try_add_wildcard_to_treeview, exclude_treeview, wildcard_entry, None, False)
+        self.builder.get_object("button_wildcard_cancel").connect("clicked", lambda _: self.wildcard_window_hide(wildcard_exclude_window, wildcard_entry, treeview, wildcard_submit_button))
 
         # set up inclusions page
         treeview = self.builder.get_object("treeview_includes")
@@ -486,8 +487,7 @@ class MintBackup:
 
         # validate user input
         if not self.wildcard_is_valid(entry_path):
-            # warn the user
-            return [], []
+            return None
 
         # match wildcards
         structure = entry_path.split("/")
@@ -541,10 +541,19 @@ class MintBackup:
 
         return is_valid
 
-    def try_add_wildcard_to_treeview(self, widget, treeview, entry, expanded):
+    def try_add_wildcard_to_treeview(self, widget, treeview, entry, submit_button, expanded):
         if expanded:
             entry_path = widget.get_text()
-            directories, files = self.get_expanded_paths(entry_path)
+            paths = self.get_expanded_paths(entry_path)
+            if paths is None:
+                widget.get_style_context().add_class("error")
+                return
+            widget.get_style_context().remove_class("error")
+            directories, files = paths
+
+            is_confirm = submit_button.get_label() == "Confirm?"
+            if is_confirm:
+                submit_button.set_label("Add wildcard")
 
             # add paths to treeview
             model = treeview.get_model()
@@ -563,7 +572,18 @@ class MintBackup:
                 model.append(item)
         else:
             entry_path = entry.get_text()
-            if not self.wildcard_is_valid(entry_path):
+            paths = self.get_expanded_paths(entry_path)
+            if paths is None:
+                widget.get_style_context().add_class("error")
+                return
+            widget.get_style_context().remove_class("error")
+            directories, files = paths
+            
+            is_confirm = widget.get_label() == "Confirm?"
+            if len(directories + files) == 0 and not is_confirm:
+                popover = self.builder.get_object("wildcard_warn_nonmatch_popover")
+                popover.popup()
+                widget.set_label("Confirm?")
                 return
 
             model = treeview.get_model()
@@ -573,12 +593,13 @@ class MintBackup:
                 treeview.get_model().append(["Wildcard", self.dir_icon, entry_path])
 
             window = self.builder.get_object("wildcard_filter")
-            self.wildcard_window_hide(window, entry, self.builder.get_object("treeview_wildcard_exclude"))
+            self.wildcard_window_hide(window, entry, self.builder.get_object("treeview_wildcard_exclude"), widget)
 
-    def wildcard_window_hide(self, window, entry, treeview):
+    def wildcard_window_hide(self, window, entry, treeview, submit_button):
         window.hide()
         entry.set_text("")
         treeview.get_model().clear()
+        submit_button.set_label("Add wildcard")
 
     # FILE BACKUP FUNCTIONS
     #############################################################################################################################

--- a/usr/lib/linuxmint/mintbackup/mintbackup.py
+++ b/usr/lib/linuxmint/mintbackup/mintbackup.py
@@ -137,8 +137,7 @@ class MintBackup:
         wildcard_entry.set_icon_from_gicon(Gtk.EntryIconPosition.SECONDARY, wildcard_help_icon)
         wildcard_entry.connect("changed", self.try_add_wildcard_to_treeview, treeview, None, True)
         self.builder.get_object("button_wildcard_submit").connect("clicked", self.try_add_wildcard_to_treeview, exclude_treeview, wildcard_entry, False)
-        # using window.clear() directly as handler freezes the application
-        self.builder.get_object("button_wildcard_cancel").connect("clicked", lambda _: wildcard_exclude_window.close())
+        self.builder.get_object("button_wildcard_cancel").connect("clicked", lambda _: self.wildcard_window_hide(wildcard_exclude_window, wildcard_entry, treeview))
 
         # set up inclusions page
         treeview = self.builder.get_object("treeview_includes")
@@ -364,7 +363,11 @@ class MintBackup:
             self.excluded_files = []
             for row in self.excludes_model:
                 item = row[2]
-                if os.path.exists(item):
+                if row[0] == "Wildcard":
+                    excluded_dirs, excluded_files = self.get_expanded_paths(item)
+                    self.excluded_dirs.extend(excluded_dirs)
+                    self.excluded_files.extend(excluded_files)
+                elif os.path.exists(item):
                     if os.path.isdir(item):
                         self.excluded_dirs.append(item)
                     else:
@@ -381,7 +384,11 @@ class MintBackup:
             self.included_files = []
             for row in self.includes_model:
                 item = row[2]
-                if os.path.exists(item):
+                if row[0] == "Wildcard":
+                    included_dirs, included_files = self.get_expanded_paths(item)
+                    self.included_dirs.extend(included_dirs)
+                    self.included_files.extend(included_files)
+                elif os.path.exists(item):
                     if os.path.isdir(item):
                         self.included_dirs.append(item)
                     else:
@@ -536,10 +543,8 @@ class MintBackup:
 
     def try_add_wildcard_to_treeview(self, widget, treeview, entry, expanded):
         if expanded:
-            entry = widget.get_text()
-            directories, files = self.get_expanded_paths(entry)
-            print(f"dirs: {directories}")
-            print(f"files: {files}")
+            entry_path = widget.get_text()
+            directories, files = self.get_expanded_paths(entry_path)
 
             # add paths to treeview
             model = treeview.get_model()
@@ -557,17 +562,23 @@ class MintBackup:
             for item in new_items:
                 model.append(item)
         else:
-            entry = entry.get_text()
-            if not self.wildcard_is_valid(entry):
+            entry_path = entry.get_text()
+            if not self.wildcard_is_valid(entry_path):
                 return
 
             model = treeview.get_model()
 
             existing_paths = {row[2] for row in model}
             if entry not in existing_paths:
-                treeview.get_model().append(["Wildcard", self.dir_icon, entry])
+                treeview.get_model().append(["Wildcard", self.dir_icon, entry_path])
 
-            self.builder.get_object("wildcard_filter").close()
+            window = self.builder.get_object("wildcard_filter")
+            self.wildcard_window_hide(window, entry, self.builder.get_object("treeview_wildcard_exclude"))
+
+    def wildcard_window_hide(self, window, entry, treeview):
+        window.hide()
+        entry.set_text("")
+        treeview.get_model().clear()
 
     # FILE BACKUP FUNCTIONS
     #############################################################################################################################

--- a/usr/lib/linuxmint/mintbackup/mintbackup.py
+++ b/usr/lib/linuxmint/mintbackup/mintbackup.py
@@ -547,6 +547,7 @@ class MintBackup:
 
     def try_add_wildcard_to_treeview(self, widget, treeview, entry, submit_button, expanded):
         if expanded:
+            home_dir = self.home_directory
             entry_path = widget.get_text()
             paths = self.get_expanded_paths(entry_path)
             if paths is None:
@@ -564,11 +565,11 @@ class MintBackup:
 
             new_items = []
             for full_path in directories:
-                _unused, item = os.path.split(full_path)
+                item = full_path[len(home_dir) + 1:]
                 new_items.append([item, self.dir_icon, full_path])
 
             for full_path in files:
-                _unused, item = os.path.split(full_path)
+                item = full_path[len(home_dir) + 1:]
                 new_items.append([item, self.file_icon, full_path])
 
             model.clear()

--- a/usr/lib/linuxmint/mintbackup/mintbackup.py
+++ b/usr/lib/linuxmint/mintbackup/mintbackup.py
@@ -365,7 +365,7 @@ class MintBackup:
             self.excluded_files = []
             for row in self.excludes_model:
                 item = row[2]
-                if row[0].startswith("Wildcard"):
+                if row[0].startswith(_("Wildcard")):
                     excluded_dirs, excluded_files = self.get_expanded_paths(item)
                     self.excluded_dirs.extend(excluded_dirs)
                     self.excluded_files.extend(excluded_files)
@@ -552,20 +552,20 @@ class MintBackup:
             widget.get_style_context().remove_class("error")
             directories, files = paths
 
-            is_confirm = submit_button.get_label() == "Confirm?"
+            is_confirm = submit_button.get_label() == _("Confirm?")
             if is_confirm:
-                submit_button.set_label("Use wildcard")
+                submit_button.set_label(_("Use wildcard"))
 
             # add paths to treeview
             model = treeview.get_model()
 
             new_items = []
             for full_path in directories:
-                _, item = os.path.split(full_path)
+                _unused, item = os.path.split(full_path)
                 new_items.append([item, self.dir_icon, full_path])
 
             for full_path in files:
-                _, item = os.path.split(full_path)
+                _unused, item = os.path.split(full_path)
                 new_items.append([item, self.file_icon, full_path])
 
             model.clear()
@@ -580,11 +580,11 @@ class MintBackup:
             widget.get_style_context().remove_class("error")
             directories, files = paths
             
-            is_confirm = widget.get_label() == "Confirm?"
+            is_confirm = widget.get_label() == _("Confirm?")
             if len(directories + files) == 0 and not is_confirm:
                 popover = self.builder.get_object("wildcard_warn_nonmatch_popover")
                 popover.popup()
-                widget.set_label("Confirm?")
+                widget.set_label(_("Confirm?"))
                 return
 
             treeview = None
@@ -600,18 +600,18 @@ class MintBackup:
 
             existing_paths = {row[2] for row in model}
             if entry not in existing_paths:
-                treeview.get_model().append([f"Wildcard: {entry_path}", self.dir_icon, entry_path])
+                treeview.get_model().append([f"{_("Wildcard")}: {entry_path}", self.dir_icon, entry_path])
 
             window = self.builder.get_object("wildcard_filter")
             self.wildcard_window_hide(window, entry, widget)
 
     def wildcard_window_show(self, widget, mode, window):
         if mode == "exclude":
-            self.builder.get_object("titlebar_wildcard").set_title("Exclude wildcard")
+            self.builder.get_object("titlebar_wildcard").set_title(_("Exclude wildcard"))
             self.builder.get_object("label_wildcard_exclude").show()
             self.builder.get_object("label_wildcard_include").hide()
         elif mode == "include":
-            self.builder.get_object("titlebar_wildcard").set_title("Include wildcard")
+            self.builder.get_object("titlebar_wildcard").set_title(("Include wildcard"))
             self.builder.get_object("label_wildcard_exclude").hide()
             self.builder.get_object("label_wildcard_include").show()
         else:
@@ -622,7 +622,7 @@ class MintBackup:
         window.hide()
         entry.set_text("")
         self.builder.get_object("treeview_wildcard").get_model().clear()
-        submit_button.set_label("Add wildcard")
+        submit_button.set_label(_("Add wildcard"))
 
     # FILE BACKUP FUNCTIONS
     #############################################################################################################################

--- a/usr/lib/linuxmint/mintbackup/mintbackup.py
+++ b/usr/lib/linuxmint/mintbackup/mintbackup.py
@@ -504,7 +504,7 @@ class MintBackup:
                 # insert file/pattern prefixes
                 # completions = [parent_pattern + entry.name for entry in entries if entry.is_dir() and entry.name in filtered_completions]
                 stored_directories.extend([entry.path for entry in entries if entry.is_dir() and entry.name in filtered])
-                stored_files.extend([path + "/" + name for name in filtered if name not in stored_directories])
+                stored_files.extend([entry.path for entry in entries if entry.is_file() and entry.name in filtered])
             scan_directories.clear()
             scan_directories.extend(stored_directories)
             stored_directories.clear()
@@ -537,6 +537,8 @@ class MintBackup:
         if expanded:
             entry = widget.get_text()
             directories, files = self.get_expanded_paths(entry)
+            print(f"dirs: {directories}")
+            print(f"files: {files}")
 
             # add paths to treeview
             model = treeview.get_model()
@@ -545,15 +547,14 @@ class MintBackup:
 
             new_items = []
             for full_path in directories:
-                if full_path not in existing_paths:
-                    _, item = os.path.split(full_path)
-                    new_items.append([item, self.dir_icon, full_path])
+                _, item = os.path.split(full_path)
+                new_items.append([item, self.dir_icon, full_path])
 
             for full_path in files:
-                if full_path not in existing_paths:
-                    _, item = os.path.split(full_path)
-                    new_items.append([item, self.file_icon, full_path])
+                _, item = os.path.split(full_path)
+                new_items.append([item, self.file_icon, full_path])
 
+            model.clear()
             for item in new_items:
                 model.append(item)
         else:

--- a/usr/lib/linuxmint/mintbackup/mintbackup.py
+++ b/usr/lib/linuxmint/mintbackup/mintbackup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+import fnmatch
 import gettext
 import hashlib
 import locale
@@ -108,10 +109,34 @@ class MintBackup:
                     self.excludes_model.append([item[len(self.home_directory) + 1:], self.dir_icon, item])
                 else:
                     self.excludes_model.append([item[len(self.home_directory) + 1:], self.file_icon, item])
+
+        wildcard_exclude_window = self.builder.get_object("wildcard_filter")
         self.builder.get_object("button_add_file").connect("clicked", self.add_item_to_treeview, treeview, self.file_icon, Gtk.FileChooserAction.OPEN, False)
         self.builder.get_object("button_add_folder").connect("clicked", self.add_item_to_treeview, treeview, self.dir_icon, Gtk.FileChooserAction.SELECT_FOLDER, False)
+        self.builder.get_object("button_add_wildcard").connect("clicked", lambda _: wildcard_exclude_window.present())
         self.builder.get_object("button_remove_exclude").connect("clicked", self.remove_item_from_treeview, treeview)
         self.builder.get_object("treeview_excludes_selection").connect("changed", self.on_treeview_excludes_selection_changed)
+
+        # set up exclusion wildcards window
+        exclude_treeview = treeview
+        treeview = self.builder.get_object("treeview_excludes")
+        renderer = Gtk.CellRendererPixbuf()
+        column = Gtk.TreeViewColumn("", renderer)
+        column.add_attribute(renderer, "pixbuf", 1)
+        treeview.append_column(column)
+        renderer = Gtk.CellRendererText()
+        column = Gtk.TreeViewColumn("", renderer)
+        column.add_attribute(renderer, "text", 0)
+        treeview.append_column(column)
+        self.excludes_model = Gtk.ListStore(str, GdkPixbuf.Pixbuf, str)
+        self.excludes_model.set_sort_column_id(0, Gtk.SortType.ASCENDING)
+        treeview.set_model(self.excludes_model)
+
+        wildcard_entry = self.builder.get_object("exclude_wildcard_entry")
+        wildcard_entry.connect("changed", self.try_add_wildcard_to_treeview, treeview, None, True)
+        self.builder.get_object("button_wildcard_submit").connect("clicked", self.try_add_wildcard_to_treeview, exclude_treeview, wildcard_entry, False)
+        # using window.clear() directly as handler freezes the application
+        self.builder.get_object("button_wildcard_cancel").connect("clicked", lambda _: wildcard_exclude_window.close())
 
         # set up inclusions page
         treeview = self.builder.get_object("treeview_includes")
@@ -441,6 +466,112 @@ class MintBackup:
                 self.builder.get_object("button_back").hide()
                 self.builder.get_object("button_forward").hide()
             self.notebook.set_current_page(sel)
+
+    def get_expanded_paths(self, entry_path):
+        home_dir = self.home_directory
+        # remove home
+        if entry_path.startswith("~/"):
+            entry_path = entry_path[2:]
+        elif entry_path.startswith(home_dir):
+            entry_path = entry_path[len(home_dir) + 1:]
+
+        # validate user input
+        if not self.wildcard_is_valid(entry_path):
+            # warn the user
+            return
+
+        # match wildcards
+        structure = entry_path.split("/")
+        scan_directories = [home_dir]
+        stored_directories = []
+        stored_files = []
+        # completions = []
+        depth = 0
+        # this loop builds the *preview* wildcard files upwards, selecting the next entries to scan from the previous iteration
+        while depth < len(structure):
+            stored_files = []
+            parent_pattern = "/".join(structure[:depth])
+            if depth > 0:
+                parent_pattern += "/"
+            pattern = structure[depth]
+            for path in scan_directories:
+                entries = list(os.scandir(path))
+                # matches files in `path` with patterns of the same depth
+                filtered = fnmatch.filter(map(lambda entry: entry.name, entries), pattern)
+                # same as above, but matches all entries which starts with a matching sequence of the pattern
+                # filtered_completions = fnmatch.filter(map(lambda entry: entry.name, entries), pattern + "*")
+
+                # insert file/pattern prefixes
+                # completions = [parent_pattern + entry.name for entry in entries if entry.is_dir() and entry.name in filtered_completions]
+                stored_directories.extend([path + "/" + entry.name for entry in entries if entry.is_dir() and entry.name in filtered])
+                stored_files.extend([path + "/" + name for name in filtered if name not in stored_directories])
+            scan_directories.clear()
+            scan_directories.extend(stored_directories)
+            stored_directories.clear()
+            depth += 1
+
+        # i tried i cant add autocompletion
+        # if anyone wants to attempt this, code to generate completions is commented out above
+        return stored_directories, stored_files
+
+    def wildcard_is_valid(self, path):
+        home_dir = self.home_directory
+        # remove home
+        is_home = False
+        if path.startswith("~/"):
+            path = path[2:]
+            is_home = True
+        elif path.startswith(home_dir):
+            path = path[len(home_dir) + 1:]
+            is_home = True
+
+        # validate user input
+        has_null = "\0" in path
+        is_root = path.startswith("/") and not is_home
+        is_valid = (not has_null) and (not is_root)
+
+        return is_valid
+
+    def try_add_wildcard_to_treeview(self, widget, treeview, entry, expanded):
+        home_dir = self.home_directory
+        if expanded:
+            entry = widget.get_text()
+            directories, files = self.get_expanded_paths(entry)
+
+            # add paths to treeview
+            model = treeview.get_model()
+
+            existing_paths = {row[2] for row in model}
+
+            new_items = []
+            for item in directories:
+                if item.startswith('.'):
+                    full_path = os.path.join(home_dir, item)
+                    if full_path not in existing_paths:
+                        if os.path.isdir(full_path):
+                            new_items.append([item, self.dir_icon, full_path])
+
+            for item in files:
+                if item.startswith('.'):
+                    full_path = os.path.join(home_dir, item)
+                    if full_path not in existing_paths:
+                        if os.path.isfile(full_path):
+                            new_items.append([item, self.file_icon, full_path])
+
+            for item in new_items:
+                model.append(item)
+        else:
+            entry = entry.get_text()
+            if not self.wildcard_is_valid(entry):
+                return
+
+            model = treeview.get_model()
+
+            existing_paths = {row[2] for row in model}
+            if entry not in existing_paths:
+                treeview.get_model().append(["Wildcard", self.dir_icon, entry])
+
+            self.builder.get_object("wildcard_filter").close()
 
     # FILE BACKUP FUNCTIONS
     #############################################################################################################################

--- a/usr/lib/linuxmint/mintbackup/mintbackup.py
+++ b/usr/lib/linuxmint/mintbackup/mintbackup.py
@@ -102,6 +102,7 @@ class MintBackup:
         self.excludes_model.append([BACKUP_DIR[len(self.home_directory) + 1:], self.dir_icon, BACKUP_DIR])
         excluded_paths.append(BACKUP_DIR)
         for item in self.settings.get_strv("excluded-paths"):
+            # BUG: gsettings init bug here
             item = os.path.expanduser(item)
             if os.path.exists(item) and item not in excluded_paths:
                 excluded_paths.append(item)
@@ -366,7 +367,7 @@ class MintBackup:
             for row in self.excludes_model:
                 item = row[2]
                 if row[0].startswith(_("Wildcard")):
-                    excluded_dirs, excluded_files = self.get_expanded_paths(item)
+                    wildcard, excluded_dirs, excluded_files = self.get_expanded_paths(item)
                     self.excluded_dirs.extend(excluded_dirs)
                     self.excluded_files.extend(excluded_files)
                 elif os.path.exists(item):
@@ -387,7 +388,7 @@ class MintBackup:
             for row in self.includes_model:
                 item = row[2]
                 if row[0].startswith("Wildcard"):
-                    included_dirs, included_files = self.get_expanded_paths(item)
+                    wildcard, included_dirs, included_files = self.get_expanded_paths(item)
                     self.included_dirs.extend(included_dirs)
                     self.included_files.extend(included_files)
                 elif os.path.exists(item):
@@ -478,20 +479,20 @@ class MintBackup:
                 self.builder.get_object("button_forward").hide()
             self.notebook.set_current_page(sel)
 
-    def get_expanded_paths(self, entry_path):
+    def get_expanded_paths(self, wildcard):
         home_dir = self.home_directory
         # remove home
-        if entry_path.startswith("~/"):
-            entry_path = entry_path[2:]
-        elif entry_path.startswith(home_dir):
-            entry_path = entry_path[len(home_dir) + 1:]
+        if wildcard.startswith("~/"):
+            wildcard = wildcard[2:]
+        elif wildcard.startswith(home_dir):
+            wildcard = wildcard[len(home_dir) + 1:]
 
         # validate user input
-        if not self.wildcard_is_valid(entry_path):
+        if not self.wildcard_is_valid(wildcard):
             return None
 
         # match wildcards
-        structure = entry_path.split("/")
+        structure = wildcard.split("/")
         scan_directories = [home_dir]
         stored_directories = []
         stored_files = []
@@ -522,7 +523,9 @@ class MintBackup:
 
         # i tried i cant add autocompletion
         # if anyone wants to attempt this, code to generate completions is commented out above
-        return scan_directories, stored_files
+        wildcard = os.path.join(self.home_directory, wildcard)
+
+        return wildcard, scan_directories, stored_files
 
     def wildcard_is_valid(self, path):
         home_dir = self.home_directory
@@ -550,7 +553,7 @@ class MintBackup:
                 widget.get_style_context().add_class("error")
                 return
             widget.get_style_context().remove_class("error")
-            directories, files = paths
+            wildcard, directories, files = paths
 
             is_confirm = submit_button.get_label() == _("Confirm?")
             if is_confirm:
@@ -578,7 +581,7 @@ class MintBackup:
                 widget.get_style_context().add_class("error")
                 return
             widget.get_style_context().remove_class("error")
-            directories, files = paths
+            wildcard, directories, files = paths
             
             is_confirm = widget.get_label() == _("Confirm?")
             if len(directories + files) == 0 and not is_confirm:
@@ -600,7 +603,7 @@ class MintBackup:
 
             existing_paths = {row[2] for row in model}
             if entry not in existing_paths:
-                treeview.get_model().append([f"{_("Wildcard")}: {entry_path}", self.dir_icon, entry_path])
+                treeview.get_model().append([f"{_("Wildcard")}: {entry_path}", self.dir_icon, wildcard])
 
             window = self.builder.get_object("wildcard_filter")
             self.wildcard_window_hide(window, entry, widget)

--- a/usr/lib/linuxmint/mintbackup/mintbackup.py
+++ b/usr/lib/linuxmint/mintbackup/mintbackup.py
@@ -137,7 +137,7 @@ class MintBackup:
         wildcard_entry.set_icon_from_gicon(Gtk.EntryIconPosition.SECONDARY, wildcard_help_icon)
         wildcard_entry.connect("changed", self.try_add_wildcard_to_treeview, treeview, None, wildcard_submit_button, True)
         self.builder.get_object("button_wildcard_submit").connect("clicked", self.try_add_wildcard_to_treeview, None, wildcard_entry, None, False)
-        self.builder.get_object("button_wildcard_cancel").connect("clicked", lambda _: self.wildcard_window_hide(wildcard_window, wildcard_entry, treeview, wildcard_submit_button))
+        self.builder.get_object("button_wildcard_cancel").connect("clicked", lambda _: self.wildcard_window_hide(wildcard_window, wildcard_entry, wildcard_submit_button))
 
         # set up inclusions page
         treeview = self.builder.get_object("treeview_includes")
@@ -554,7 +554,7 @@ class MintBackup:
 
             is_confirm = submit_button.get_label() == "Confirm?"
             if is_confirm:
-                submit_button.set_label("Add wildcard")
+                submit_button.set_label("Use wildcard")
 
             # add paths to treeview
             model = treeview.get_model()

--- a/usr/lib/linuxmint/mintbackup/mintbackup.py
+++ b/usr/lib/linuxmint/mintbackup/mintbackup.py
@@ -622,7 +622,7 @@ class MintBackup:
         window.hide()
         entry.set_text("")
         self.builder.get_object("treeview_wildcard").get_model().clear()
-        submit_button.set_label(_("Add wildcard"))
+        submit_button.set_label(_("Use wildcard"))
 
     # FILE BACKUP FUNCTIONS
     #############################################################################################################################

--- a/usr/lib/linuxmint/mintbackup/mintbackup.py
+++ b/usr/lib/linuxmint/mintbackup/mintbackup.py
@@ -133,6 +133,8 @@ class MintBackup:
         treeview.set_model(self.excludes_model)
 
         wildcard_entry = self.builder.get_object("exclude_wildcard_entry")
+        wildcard_help_icon = self.iconTheme.load_icon("xsi-dialog-question-symbolic", 16, 0)
+        wildcard_entry.set_icon_from_gicon(Gtk.EntryIconPosition.SECONDARY, wildcard_help_icon)
         wildcard_entry.connect("changed", self.try_add_wildcard_to_treeview, treeview, None, True)
         self.builder.get_object("button_wildcard_submit").connect("clicked", self.try_add_wildcard_to_treeview, exclude_treeview, wildcard_entry, False)
         # using window.clear() directly as handler freezes the application

--- a/usr/lib/linuxmint/mintbackup/mintbackup.py
+++ b/usr/lib/linuxmint/mintbackup/mintbackup.py
@@ -110,16 +110,16 @@ class MintBackup:
                 else:
                     self.excludes_model.append([item[len(self.home_directory) + 1:], self.file_icon, item])
 
-        wildcard_exclude_window = self.builder.get_object("wildcard_filter")
+        wildcard_window = self.builder.get_object("wildcard_filter")
         self.builder.get_object("button_add_file").connect("clicked", self.add_item_to_treeview, treeview, self.file_icon, Gtk.FileChooserAction.OPEN, False)
         self.builder.get_object("button_add_folder").connect("clicked", self.add_item_to_treeview, treeview, self.dir_icon, Gtk.FileChooserAction.SELECT_FOLDER, False)
-        self.builder.get_object("button_add_wildcard").connect("clicked", lambda _: wildcard_exclude_window.present())
+        self.builder.get_object("button_add_wildcard_exclude").connect("clicked", self.wildcard_window_show, "exclude", wildcard_window)
         self.builder.get_object("button_remove_exclude").connect("clicked", self.remove_item_from_treeview, treeview)
         self.builder.get_object("treeview_excludes_selection").connect("changed", self.on_treeview_excludes_selection_changed)
 
-        # set up exclusion wildcards window
+        # set up exclude wildcards window
         exclude_treeview = treeview
-        treeview = self.builder.get_object("treeview_wildcard_exclude")
+        treeview = self.builder.get_object("treeview_wildcard")
         renderer = Gtk.CellRendererPixbuf()
         column = Gtk.TreeViewColumn("", renderer)
         column.add_attribute(renderer, "pixbuf", 1)
@@ -133,12 +133,12 @@ class MintBackup:
         treeview.set_model(self.excludes_model)
 
         wildcard_submit_button = self.builder.get_object("button_wildcard_submit")
-        wildcard_entry = self.builder.get_object("exclude_wildcard_entry")
+        wildcard_entry = self.builder.get_object("wildcard_entry")
         wildcard_help_icon = self.iconTheme.load_icon("xsi-dialog-question-symbolic", 16, 0)
         wildcard_entry.set_icon_from_gicon(Gtk.EntryIconPosition.SECONDARY, wildcard_help_icon)
         wildcard_entry.connect("changed", self.try_add_wildcard_to_treeview, treeview, None, wildcard_submit_button, True)
         self.builder.get_object("button_wildcard_submit").connect("clicked", self.try_add_wildcard_to_treeview, exclude_treeview, wildcard_entry, None, False)
-        self.builder.get_object("button_wildcard_cancel").connect("clicked", lambda _: self.wildcard_window_hide(wildcard_exclude_window, wildcard_entry, treeview, wildcard_submit_button))
+        self.builder.get_object("button_wildcard_cancel").connect("clicked", lambda _: self.wildcard_window_hide(wildcard_window, wildcard_entry, treeview, wildcard_submit_button))
 
         # set up inclusions page
         treeview = self.builder.get_object("treeview_includes")
@@ -160,8 +160,10 @@ class MintBackup:
                     self.includes_model.append([item[len(self.home_directory) + 1:], self.dir_icon, item])
                 else:
                     self.includes_model.append([item[len(self.home_directory) + 1:], self.file_icon, item])
+
         self.builder.get_object("button_include_hidden_files").connect("clicked", self.add_item_to_treeview, treeview, self.file_icon, Gtk.FileChooserAction.OPEN, True)
         self.builder.get_object("button_include_hidden_dirs").connect("clicked", self.add_item_to_treeview, treeview, self.dir_icon, Gtk.FileChooserAction.SELECT_FOLDER, True)
+        self.builder.get_object("button_add_wildcard_include").connect("clicked", self.wildcard_window_show, "include", wildcard_window)
         self.builder.get_object("button_include_all_hidden").connect("clicked", self.add_all_hidden_to_treeview, treeview)
         self.builder.get_object("button_remove_include").connect("clicked", self.remove_item_from_treeview, treeview)
 
@@ -364,7 +366,7 @@ class MintBackup:
             self.excluded_files = []
             for row in self.excludes_model:
                 item = row[2]
-                if row[0] == "Wildcard":
+                if row[0].startswith("Wildcard"):
                     excluded_dirs, excluded_files = self.get_expanded_paths(item)
                     self.excluded_dirs.extend(excluded_dirs)
                     self.excluded_files.extend(excluded_files)
@@ -385,7 +387,7 @@ class MintBackup:
             self.included_files = []
             for row in self.includes_model:
                 item = row[2]
-                if row[0] == "Wildcard":
+                if row[0].startswith("Wildcard"):
                     included_dirs, included_files = self.get_expanded_paths(item)
                     self.included_dirs.extend(included_dirs)
                     self.included_files.extend(included_files)
@@ -496,7 +498,7 @@ class MintBackup:
         stored_files = []
         # completions = []
         depth = 0
-        # this loop builds the *preview* wildcard files upwards, selecting the next entries to scan from the previous iteration
+        # this loop builds the wildcard files upwards, selecting the next entries to scan from the previous iteration
         while depth < len(structure):
             stored_files = []
             parent_pattern = "/".join(structure[:depth])
@@ -508,7 +510,7 @@ class MintBackup:
                 # matches files in `path` with patterns of the same depth
                 filtered = fnmatch.filter(map(lambda entry: entry.name, entries), pattern)
                 # same as above, but matches all entries which starts with a matching sequence of the pattern
-                # filtered_completions = fnmatch.filter(map(lambda entry: entry.name, entries), pattern + "*")
+                # filtered_completions = fnmatch.filter(map(lambda entry: entry.name, entries), pattern + "*" if pattern[-1] != "*" else pattern + "/*")
 
                 # insert file/pattern prefixes
                 # completions = [parent_pattern + entry.name for entry in entries if entry.is_dir() and entry.name in filtered_completions]
@@ -586,19 +588,41 @@ class MintBackup:
                 widget.set_label("Confirm?")
                 return
 
+            treeview = None
+            if self.builder.get_object("label_wildcard_exclude").is_visible():
+                treeview = self.builder.get_object("treeview_excludes")
+            elif self.builder.get_object("label_wildcard_include").is_visible():
+                treeview = self.builder.get_object("treeview_includes")
+            else:
+                print("No mode selected", file=sys.stderr)
+                return
+
             model = treeview.get_model()
 
             existing_paths = {row[2] for row in model}
             if entry not in existing_paths:
-                treeview.get_model().append(["Wildcard", self.dir_icon, entry_path])
+                treeview.get_model().append([f"Wildcard: {entry_path}", self.dir_icon, entry_path])
 
             window = self.builder.get_object("wildcard_filter")
-            self.wildcard_window_hide(window, entry, self.builder.get_object("treeview_wildcard_exclude"), widget)
+            self.wildcard_window_hide(window, entry, widget)
 
-    def wildcard_window_hide(self, window, entry, treeview, submit_button):
+    def wildcard_window_show(self, widget, mode, window):
+        if mode == "exclude":
+            self.builder.get_object("titlebar_wildcard").set_title("Exclude wildcard")
+            self.builder.get_object("label_wildcard_exclude").show()
+            self.builder.get_object("label_wildcard_include").hide()
+        elif mode == "include":
+            self.builder.get_object("titlebar_wildcard").set_title("Include wildcard")
+            self.builder.get_object("label_wildcard_exclude").hide()
+            self.builder.get_object("label_wildcard_include").show()
+        else:
+            raise ValueError(f"Invalid mode: {mode}")
+        window.present()
+
+    def wildcard_window_hide(self, window, entry, submit_button):
         window.hide()
         entry.set_text("")
-        treeview.get_model().clear()
+        self.builder.get_object("treeview_wildcard").get_model().clear()
         submit_button.set_label("Add wildcard")
 
     # FILE BACKUP FUNCTIONS

--- a/usr/share/linuxmint/mintbackup/mintbackup.ui
+++ b/usr/share/linuxmint/mintbackup/mintbackup.ui
@@ -1562,18 +1562,6 @@
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="truncate-multiline">True</property>
-                    <property name="primary-icon-tooltip-markup" translatable="yes">Use '*' to match multiple characters,
-'?' to match a single character,
-'[' and ']' to match a set of characters.
-Use '!' to exclude a set of characters.
-
-Usage examples:
-- '*.png' matches all files ending with '.png'
-- 'image1?.png' matches files like 'image14.png' or 'image1a.png', but not 'image1ab.png'
-- '[abc].jpg' matches files 'a.jpg', 'b.jpg', 'c.jpg'
-- '[a-z].png' matches files 'a.png', 'b.png', 'c.png', ..., 'z.png'
-- '[!cd].png' matches files like 'a.png', '1.png', but not  'c.png' or ' 'd.png''
-- '[abc]*.jpg' matches all files containing any number of characters 'a', 'b', and 'c' and ending with '.jpg', like 'acbabacbb.jpg'</property>
                     <property name="secondary-icon-tooltip-markup" translatable="yes" comments="good luck">Use '*' to match multiple characters,
 '?' to match a single character,
 '[' and ']' to match a set of characters.

--- a/usr/share/linuxmint/mintbackup/mintbackup.ui
+++ b/usr/share/linuxmint/mintbackup/mintbackup.ui
@@ -1702,7 +1702,7 @@ Usage examples:
         <property name="margin">4</property>
         <child>
           <object class="GtkLabel">
-            <property name="label">The entered wildcard does not match any files. Click again to proceed.</property>
+            <property name="label" translatable="yes">The entered wildcard does not match any files. Click again to proceed.</property>
             <property name="visible">True</property>
           </object>
           <packing>

--- a/usr/share/linuxmint/mintbackup/mintbackup.ui
+++ b/usr/share/linuxmint/mintbackup/mintbackup.ui
@@ -405,7 +405,7 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkButton" id="button_add_wildcard">
+                          <object class="GtkButton" id="button_add_wildcard_exclude">
                             <property name="label" translatable="yes">Exclude wildcard</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
@@ -548,6 +548,19 @@
                           </packing>
                         </child>
                         <child>
+                          <object class="GtkButton" id="button_add_wildcard_include">
+                            <property name="label" translatable="yes">Include wildcard</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <child>
                           <object class="GtkButton" id="button_include_all_hidden">
                             <property name="label" translatable="yes">Include all</property>
                             <property name="visible">True</property>
@@ -557,7 +570,7 @@
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">False</property>
-                            <property name="position">2</property>
+                            <property name="position">3</property>
                           </packing>
                         </child>
                         <child>
@@ -1533,8 +1546,21 @@
         <property name="orientation">vertical</property>
         <property name="spacing">6</property>
         <child>
-          <object class="GtkLabel" id="label5">
-            <property name="visible">True</property>
+          <object class="GtkLabel" id="label_wildcard_include">
+            <property name="visible">False</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Please add files or directories to the list below to include them in the backup.</property>
+            <property name="xalign">0</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="label_wildcard_exclude">
+            <property name="visible">False</property>
             <property name="can-focus">False</property>
             <property name="label" translatable="yes">Please add files or directories to the list below to exclude them from the backup.</property>
             <property name="xalign">0</property>
@@ -1558,7 +1584,7 @@
                 <property name="orientation">vertical</property>
                 <property name="expand">True</property>
                 <child>
-                  <object class="GtkEntry" id="exclude_wildcard_entry">
+                  <object class="GtkEntry" id="wildcard_entry">
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="truncate-multiline">True</property>
@@ -1583,7 +1609,7 @@ Usage examples:
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkScrolledWindow" id="scrolledwindow_wildcard_exclude">
+                  <object class="GtkScrolledWindow" id="scrolledwindow_wildcard">
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="shadow-type">out</property>
@@ -1593,7 +1619,7 @@ Usage examples:
                         <property name="can-focus">False</property>
                         <property name="resize-mode">queue</property>
                         <child>
-                          <object class="GtkTreeView" id="treeview_wildcard_exclude">
+                          <object class="GtkTreeView" id="treeview_wildcard">
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="headers-visible">False</property>
@@ -1658,7 +1684,7 @@ Usage examples:
       </object>
     </child>
     <child type="titlebar">
-      <object class="GtkHeaderBar">
+      <object class="GtkHeaderBar" id="titlebar_wildcard">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="title" translatable="yes">Exclude Filter</property>

--- a/usr/share/linuxmint/mintbackup/mintbackup.ui
+++ b/usr/share/linuxmint/mintbackup/mintbackup.ui
@@ -1599,7 +1599,7 @@ Usage examples:
 - '[abc].jpg' matches files 'a.jpg', 'b.jpg', 'c.jpg'
 - '[a-z].png' matches files 'a.png', 'b.png', 'c.png', ..., 'z.png'
 - '[!cd].png' matches files like 'a.png', '1.png', but not  'c.png' or ' 'd.png''
-- '[abc]*.jpg' matches all files containing any number of characters 'a', 'b', and 'c' and ending with '.jpg', like 'acbabacbb.jpg'</property>
+- '[abc]*.jpg' matches all files starting with either 'a', 'b', and 'c' and ending with '.jpg', like 'apple.jpg'</property>
                     <property name="placeholder-text" translatable="yes">Enter a path wildcard (eg. Pictures/Important/*.png)</property>
                   </object>
                   <packing>

--- a/usr/share/linuxmint/mintbackup/mintbackup.ui
+++ b/usr/share/linuxmint/mintbackup/mintbackup.ui
@@ -1666,4 +1666,25 @@ Usage examples:
       </object>
     </child>
   </object>
+  <object class="GtkPopover" id="wildcard_warn_nonmatch_popover">
+    <property name="relative-to">button_wildcard_submit</property>
+    <child>
+      <object class="GtkBox" id="vbox9">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="margin">4</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="label">The entered wildcard does not match any files. Click again to proceed.</property>
+            <property name="visible">True</property>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
 </interface>

--- a/usr/share/linuxmint/mintbackup/mintbackup.ui
+++ b/usr/share/linuxmint/mintbackup/mintbackup.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkFileFilter" id="filefilter1">
@@ -405,6 +405,19 @@
                           </packing>
                         </child>
                         <child>
+                          <object class="GtkButton" id="button_add_wildcard">
+                            <property name="label" translatable="yes">Exclude wildcard</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <child>
                           <object class="GtkButton" id="button_remove_exclude">
                             <property name="label" translatable="yes">Remove</property>
                             <property name="visible">True</property>
@@ -415,7 +428,7 @@
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">False</property>
-                            <property name="position">2</property>
+                            <property name="position">3</property>
                           </packing>
                         </child>
                       </object>
@@ -1504,6 +1517,164 @@
             </child>
           </object>
         </child>
+      </object>
+    </child>
+  </object>
+  <object class="GtkWindow" id="wildcard_filter">
+    <property name="transient-for">main_window</property>
+    <property name="modal">True</property>
+    <property name="destroy-with-parent">True</property>
+    <property name="skip-taskbar-hint">True</property>
+    <child>
+      <object class="GtkBox" id="vbox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="border-width">12</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">6</property>
+        <child>
+          <object class="GtkLabel" id="label5">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Please add files or directories to the list below to exclude them from the backup.</property>
+            <property name="xalign">0</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="hbox4">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="orientation">horizontal</property>
+            <property name="spacing">12</property>
+            <child>
+              <object class="GtkBox" id="vbox25">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="orientation">vertical</property>
+                <property name="expand">True</property>
+                <child>
+                  <object class="GtkEntry" id="exclude_wildcard_entry">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="truncate-multiline">True</property>
+                    <property name="primary-icon-tooltip-markup" translatable="yes">Use '*' to match multiple characters,
+'?' to match a single character,
+'[' and ']' to match a set of characters.
+Use '!' to exclude a set of characters.
+
+Usage examples:
+- '*.png' matches all files ending with '.png'
+- 'image1?.png' matches files like 'image14.png' or 'image1a.png', but not 'image1ab.png'
+- '[abc].jpg' matches files 'a.jpg', 'b.jpg', 'c.jpg'
+- '[a-z].png' matches files 'a.png', 'b.png', 'c.png', ..., 'z.png'
+- '[!cd].png' matches files like 'a.png', '1.png', but not  'c.png' or ' 'd.png''
+- '[abc]*.jpg' matches all files containing any number of characters 'a', 'b', and 'c' and ending with '.jpg', like 'acbabacbb.jpg'</property>
+                    <property name="secondary-icon-tooltip-markup" translatable="yes" comments="good luck">Use '*' to match multiple characters,
+'?' to match a single character,
+'[' and ']' to match a set of characters.
+Use '!' to exclude a set of characters.
+
+Usage examples:
+- '*.png' matches all files ending with '.png'
+- 'image1?.png' matches files like 'image14.png' or 'image1a.png', but not 'image1ab.png'
+- '[abc].jpg' matches files 'a.jpg', 'b.jpg', 'c.jpg'
+- '[a-z].png' matches files 'a.png', 'b.png', 'c.png', ..., 'z.png'
+- '[!cd].png' matches files like 'a.png', '1.png', but not  'c.png' or ' 'd.png''
+- '[abc]*.jpg' matches all files containing any number of characters 'a', 'b', and 'c' and ending with '.jpg', like 'acbabacbb.jpg'</property>
+                    <property name="placeholder-text" translatable="yes">Enter a path wildcard (eg. Pictures/Important/*.png)</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkScrolledWindow" id="scrolledwindow_wildcard_exclude">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="shadow-type">out</property>
+                    <child>
+                      <object class="GtkViewport" id="viewport1">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="resize-mode">queue</property>
+                        <child>
+                          <object class="GtkTreeView" id="treeview_wildcard_exclude">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="headers-visible">False</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="padding">6</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkBox" id="vbox24">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkButton" id="button_wildcard_cancel">
+                    <property name="label" translatable="yes">Cancel</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                  </object>
+                  <packing>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="button_wildcard_submit">
+                    <property name="label" translatable="yes">Use wildcard</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                  </object>
+                  <packing>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <child type="titlebar">
+      <object class="GtkHeaderBar">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="title" translatable="yes">Exclude Filter</property>
+        <property name="spacing">2</property>
       </object>
     </child>
   </object>


### PR DESCRIPTION
### Summary
Adds the ability to specify wildcard patterns (glob-style) when adding items to the backup exclude and include lists, in addition to the existing file/folder pickers.

### Motivation
Previously, users could only exclude or include specific files or directories by navigating to them individually. There was no way to express patterns like "all `.log` files under `~/.local`" or "any folder named `cache` anywhere in the home directory." This change adds a dedicated wildcard entry UI to cover those cases.

### Changes

**`usr/lib/linuxmint/mintbackup/mintbackup.py`**
- Added `import fnmatch` to support glob-style pattern matching.
- `get_expanded_paths(entry_path)`: Resolves a wildcard pattern (relative to `~`) into a list of matching directories and files by walking the filesystem depth-by-depth, matching each path component against its pattern segment.
- `wildcard_is_valid(path)`: Validates that a user-supplied pattern does not contain null bytes or attempt to escape the home directory via an absolute path.
- `try_add_wildcard_to_treeview(...)`: Handles both live preview (called on `changed` from the entry widget) and final submission (called on button click). Shows a "Confirm?" popover warning when the pattern matches nothing, requiring a second click to proceed.
- `wildcard_window_show(widget, mode, window)`: Opens the wildcard dialog and configures its title and label for either "exclude" or "include" mode.
- `wildcard_window_hide(window, entry, submit_button)`: Clears the entry, preview treeview, and button label when closing the dialog.
- Updated the exclude/include list-building loops to recognise rows starting with `"Wildcard"` and expand them via `get_expanded_paths` immediately before backup.

**`usr/share/linuxmint/mintbackup/mintbackup.ui`**
- Added **"Exclude wildcard"** and **"Include wildcard"** buttons as the third button from top down of the button boxes.
- Added a new `GtkWindow` (`wildcard_filter`) containing:
  - A `GtkEntry` (`wildcard_entry`) with a help icon whose tooltip explains supported syntax (`*`, `?`, `[...]`, `[!...]`) with examples.
  - A live-preview `GtkTreeView` (`treeview_wildcard`) that shows files and directories matched by the current pattern as the user types.
  - **Cancel** and **Use wildcard** action buttons.
  - Mode-specific instruction labels (`label_wildcard_exclude` / `label_wildcard_include`).
- Added a `GtkPopover` (`wildcard_warn_nonmatch_popover`) anchored to the submit button, shown when the entered pattern matches no files, prompting the user to confirm before adding a zero-match wildcard.

### Supported syntax
Patterns follow standard Python `fnmatch` / Unix glob conventions:

| Pattern | Matches |
|---|---|
| `*.png` | All `.png` files in the matched directory |
| `image1?.png` | Single-character wildcard (`image14.png`, `image1a.png`) |
| `[abc].jpg` | Exactly one character from the set |
| `[a-z].png` | Any lowercase letter |
| `[!cd].png` | Any character except `c` or `d` |
| `Pictures/Important/*.png` | Multi-segment path with wildcard leaf |

please review im not too sure if i missed anything stupid